### PR TITLE
Update dac_sdc.ipynb

### DIFF
--- a/sample_team/dac_sdc.ipynb
+++ b/sample_team/dac_sdc.ipynb
@@ -185,9 +185,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "xlnk = pynq.Xlnk()\n",
-    "in_buffer = xlnk.cma_array(shape=(453, 674, 3), dtype=np.uint8, cacheable = 1)\n",
-    "out_buffer = xlnk.cma_array(shape=(453, 674, 3), dtype=np.uint8, cacheable = 1)"
+    "in_buffer = pynq.allocate(shape=(453, 674, 3), dtype=np.uint8, cacheable = 1)\n",
+    "out_buffer = pynq.allocate(shape=(453, 674, 3), dtype=np.uint8, cacheable = 1)"
    ]
   },
   {
@@ -340,7 +339,8 @@
     "print(\"XML results written successfully.\")\n",
     "\n",
     "# Remember to free the contiguous memory after usage.\n",
-    "xlnk.xlnk_reset()"
+    "del in_buffer\n",
+    "del out_buffer"
    ]
   },
   {


### PR DESCRIPTION
### Addressed this issue:
/usr/lib/python3/dist-packages/ipykernel_launcher.py:1: DeprecationWarning: pynq.Xlnk is deprecated and will be removed in 2.7 - use pynq.allocate instead
  """Entry point for launching an IPython kernel.